### PR TITLE
upgrade to 15.04 chroot for crosscompile armhf

### DIFF
--- a/build-in-chroot.sh
+++ b/build-in-chroot.sh
@@ -18,9 +18,9 @@ find $CLICK_DIR/.. -name "*.click" -exec rm {} \;
 
 # Build the project
 
-click chroot -a armhf -f ubuntu-sdk-14.10 -s utopic run CGO_ENABLED=1 GOARCH=arm GOARM=7 PKG_CONFIG_LIBDIR=/usr/lib/arm-linux-gnueabihf/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig GOPATH=$DIR GOROOT=$GO_DIR CC=arm-linux-gnueabihf-gcc $GO_BIN_DIR/go get -d -u gopkg.in/qml.v1
+click chroot -a armhf -f ubuntu-sdk-15.04 -s vivid run CGO_ENABLED=1 GOARCH=arm GOARM=7 PKG_CONFIG_LIBDIR=/usr/lib/arm-linux-gnueabihf/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig GOPATH=$DIR GOROOT=$GO_DIR CC=arm-linux-gnueabihf-gcc $GO_BIN_DIR/go get -d -u gopkg.in/qml.v1
 
-click chroot -a armhf -f ubuntu-sdk-14.10 -s utopic run CGO_ENABLED=1 GOARCH=arm GOARM=7 PKG_CONFIG_LIBDIR=/usr/lib/arm-linux-gnueabihf/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig GOPATH=$DIR GOROOT=$GO_DIR CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ $GO_BIN_DIR/go install -ldflags '-extld=arm-linux-gnueabihf-gcc' -v -x ubuntu-go-qml-template
+click chroot -a armhf -f ubuntu-sdk-15.04 -s vivid run CGO_ENABLED=1 GOARCH=arm GOARM=7 PKG_CONFIG_LIBDIR=/usr/lib/arm-linux-gnueabihf/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig GOPATH=$DIR GOROOT=$GO_DIR CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ $GO_BIN_DIR/go install -ldflags '-extld=arm-linux-gnueabihf-gcc' -v -x ubuntu-go-qml-template
 
 # Copy files into click directory
 

--- a/chroot-scripts/install-go-1-3-3.sh
+++ b/chroot-scripts/install-go-1-3-3.sh
@@ -32,10 +32,10 @@ echo "====================================="
 echo
 
 if [ $ARCH = "x86_64" ]; then
-	sudo click chroot -a armhf -f ubuntu-sdk-14.10 -s utopic maint tar -C $INSTALL_DIR -xzf $INSTALL_DIR/go1.3.3.linux-amd64.tar.gz
+	sudo click chroot -a armhf -f ubuntu-sdk-15.04 -s vivid maint tar -C $INSTALL_DIR -xzf $INSTALL_DIR/go1.3.3.linux-amd64.tar.gz
 	rm $INSTALL_DIR/go1.3.3.linux-amd64.tar.gz
 else
-	sudo click chroot -a armhf -f ubuntu-sdk-14.10 -s utopic maint tar -C $INSTALL_DIR -xzf $INSTALL_DIR/go1.3.3.linux-386.tar.gz
+	sudo click chroot -a armhf -f ubuntu-sdk-15.04 -s vivid maint tar -C $INSTALL_DIR -xzf $INSTALL_DIR/go1.3.3.linux-386.tar.gz
 	rm $INSTALL_DIR/go1.3.3.linux-386.tar.gz
 fi
 

--- a/chroot-scripts/setup-chroot.sh
+++ b/chroot-scripts/setup-chroot.sh
@@ -7,8 +7,8 @@ echo "========== Creating chroot =========="
 echo "====================================="
 echo
 
-sudo click chroot -a armhf -f ubuntu-sdk-14.10 -s utopic create
-sudo click chroot -a armhf -f ubuntu-sdk-14.10 -s utopic upgrade
+sudo click chroot -a armhf -f ubuntu-sdk-15.04 -s vivid create
+sudo click chroot -a armhf -f ubuntu-sdk-15.04 -s vivid upgrade
 
 echo
 echo "====================================="
@@ -16,7 +16,7 @@ echo "=== Installing packages in chroot ==="
 echo "====================================="
 echo
 
-sudo click chroot -a armhf -f ubuntu-sdk-14.10 -s utopic maint apt-get install git qtdeclarative5-dev:armhf qtbase5-private-dev:armhf qtdeclarative5-private-dev:armhf libqt5opengl5-dev:armhf qtdeclarative5-qtquick2-plugin:armhf
+sudo click chroot -a armhf -f ubuntu-sdk-15.04 -s vivid maint apt-get install git qtdeclarative5-dev:armhf qtbase5-private-dev:armhf qtdeclarative5-private-dev:armhf libqt5opengl5-dev:armhf qtdeclarative5-qtquick2-plugin:armhf
 
 GO_DIR=$DIR/../go-installation
 

--- a/manifest.json
+++ b/manifest.json
@@ -11,5 +11,5 @@
     },
     "version": "0.1",
     "maintainer": "Niklas Wenzel <nikwen.developer@gmail.com>",
-    "framework" : "ubuntu-sdk-14.10"
+    "framework" : "ubuntu-sdk-15.04"
 }

--- a/share/ubuntu-go-qml-template/main.qml
+++ b/share/ubuntu-go-qml-template/main.qml
@@ -1,5 +1,5 @@
 import QtQuick 2.0
-import Ubuntu.Components 1.1
+import Ubuntu.Components 1.2
 
 /*!
     \brief MainView with a Label and Button elements.
@@ -17,9 +17,6 @@ MainView {
      when the device is rotated. The default is false.
     */
     //automaticOrientation: true
-
-    // Removes the old toolbar and enables new features of the new header.
-    useDeprecatedToolbar: false
 
     width: units.gu(100)
     height: units.gu(75)

--- a/ubuntu-go-qml-template.apparmor
+++ b/ubuntu-go-qml-template.apparmor
@@ -2,7 +2,7 @@
     "policy_groups": [
         "networking"
     ],
-    "policy_version": 1.2
+    "policy_version": 1.3
 }
 
 


### PR DESCRIPTION
This PR gets rid of ubuntu 14.10 for building the chroot -> eol reached in favour of 15.04
makes use of Ubuntu.Components 1.2 and minor changes to main.qml
